### PR TITLE
Try adapt to 1.19.0 rc.5

### DIFF
--- a/Bullseye.csproj
+++ b/Bullseye.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
     <PropertyGroup>
         <ModId>bullseye</ModId>
-        <VSVersion>1.18.10</VSVersion>
+        <VSVersion>1.19.0-rc.5</VSVersion>
         <ModWebsite>https://mods.vintagestory.at/bullseye</ModWebsite>
     </PropertyGroup>
     <ItemGroup>

--- a/src/BullseyeCollectibleBehaviorAnimatable.cs
+++ b/src/BullseyeCollectibleBehaviorAnimatable.cs
@@ -258,7 +258,7 @@ namespace Bullseye
 		{
 			if (onlyWhenAnimating && ActiveAnimationsByAnimCode.Count == 0)
 			{
-				capi.Render.RenderMesh(renderInfo.ModelRef);
+				capi.Render.RenderMultiTextureMesh(renderInfo.ModelRef);
 			}
 			else
 			{

--- a/src/BullseyeCollectibleBehaviorAnimatableAttach.cs
+++ b/src/BullseyeCollectibleBehaviorAnimatableAttach.cs
@@ -83,7 +83,7 @@ namespace Bullseye
 
 				prog.UniformMatrix("modelViewMatrix", AttachedMeshMat.Values);
 
-				capi.Render.RenderMesh(AttachedRenderInfo.ModelRef);
+				capi.Render.RenderMultiTextureMesh(AttachedRenderInfo.ModelRef);
 			}
 		}
 	}

--- a/src/BullseyeCollectibleBehaviorBow.cs
+++ b/src/BullseyeCollectibleBehaviorBow.cs
@@ -103,7 +103,7 @@ namespace Bullseye
 
 				if (api is ICoreClientAPI capi)
 				{
-					ItemRenderInfo renderInfo = capi.Render.GetItemStackRenderInfo(arrowSlot, EnumItemRenderTarget.Ground);
+					ItemRenderInfo renderInfo = capi.Render.GetItemStackRenderInfo(arrowSlot, EnumItemRenderTarget.Ground, 0);
 					renderInfo.Transform = renderInfo.Transform.Clone();
 
 					// Scale arrows down - ground model of arrows is 21 voxels long, but in bows, the arrows are only 15 units long

--- a/src/Legacy/BullseyeItemBow.cs
+++ b/src/Legacy/BullseyeItemBow.cs
@@ -170,7 +170,7 @@ namespace Bullseye
 
 				if (api is ICoreClientAPI capi)
 				{
-					ItemRenderInfo renderInfo = capi.Render.GetItemStackRenderInfo(arrowSlot, EnumItemRenderTarget.Ground);
+					ItemRenderInfo renderInfo = capi.Render.GetItemStackRenderInfo(arrowSlot, EnumItemRenderTarget.Ground, 0);
 
 					float arrowScale = weaponSlot.Itemstack?.Collectible?.Attributes?["arrowScale"].AsFloat(1) ?? 1f;
 


### PR DESCRIPTION
Tried to resolve #14 and didn't stumble upon bugs or crushes. But I still don't know what is `dt` parameter in `GetItemStackRenderInfo(ItemSlot inSlot, EnumItemRenderTarget ground, float dt)`, and am quite sure about just plugging 0 there
